### PR TITLE
add Xcheck:jni flag

### DIFF
--- a/check-leak/pom.xml
+++ b/check-leak/pom.xml
@@ -137,7 +137,7 @@
                   <testFailureIgnore>false</testFailureIgnore>
                   <runOrder>alphabetical</runOrder>
                   <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                  <argLine>${native-surefire-argline}</argLine>
+                  <argLine>${native-surefire-argline} -Xcheck:jni</argLine>
                </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
# Motivation

Run testsuite with '-Xcheck:jni' to ensure we catch bugs in JNI code which could later cause issues like crashes

# Modifications

Add -Xcheck:jni

# Result

Testsuite will be able to catch more JNI bugs

# Related work

This PR was inspired by a Netty PR:
https://github.com/netty/netty/pull/13642

# JDK documentation 

https://docs.oracle.com/en/java/javase/11/tools/java.html


![image](https://github.com/check-leak/check-leak/assets/30938/ef60e4e4-062f-4d46-85a4-25b8f2daae23)

